### PR TITLE
better default month handling

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -43,11 +43,10 @@ export default class Calendar extends Component {
   componentWillReceiveProps({selectedDay, defaultMonth, min}) {
     if (this.props.selectedDay !== selectedDay) {
       this.selectDay(selectedDay);
-    }
-    if (defaultMonth && this.props.defaultMonth !== defaultMonth) {
+    } else if (defaultMonth && this.props.defaultMonth !== defaultMonth && this.state.month === this.props.defaultMonth) {
       this.setMonth(defaultMonth);
-    } else if (this.props.min !== min) {
-      this.setMonth(moment(min));
+    } else if (min && this.props.min !== min && this.state.month.isSame(this.props.min)) {
+      this.setMonth(min.clone());
     }
   }
 

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -26,7 +26,7 @@ export default class Calendar extends Component {
   };
 
   state = {
-    month: this.props.defaultMonth || this.props.selectedDay || moment(),
+    month: this.props.defaultMonth || this.props.selectedDay || moment(this.props.min),
     selectedDay: this.props.selectedDay || null,
     mode: 'days'
   };
@@ -40,9 +40,14 @@ export default class Calendar extends Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.selectedDay !== nextProps.selectedDay) {
-      this.selectDay(nextProps.selectedDay);
+  componentWillReceiveProps({selectedDay, defaultMonth, min}) {
+    if (this.props.selectedDay !== selectedDay) {
+      this.selectDay(selectedDay);
+    }
+    if (defaultMonth && this.props.defaultMonth !== defaultMonth) {
+      this.setMonth(defaultMonth);
+    } else if (this.props.min !== min) {
+      this.setMonth(moment(min));
     }
   }
 
@@ -136,3 +141,4 @@ export default class Calendar extends Component {
     </div>);
   }
 }
+

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -23,7 +23,6 @@ const styles = {
   calendar: {
     position: 'absolute',
     top: '100%',
-    left: 0,
     transition: 'all .3s ease',
     zIndex: '9999'
   }
@@ -36,6 +35,7 @@ export default class DatePicker extends Component {
     children: PropTypes.node,
     min: PropTypes.object,
     max: PropTypes.object,
+    defaultMonth: PropTypes.object,
     displayFormat: PropTypes.string
   };
 
@@ -116,7 +116,7 @@ export default class DatePicker extends Component {
 
   render() {
     const { visible, inputValue, value } = this.state;
-    const { min, max, children, ...rest } = this.props;
+    const { min, max, defaultMonth, children, ...rest } = this.props;
 
     const calendarVisibilityStyle = visible ? styles.calendarVisible : styles.calendarHidden;
     const calendarStyles = {
@@ -139,6 +139,7 @@ export default class DatePicker extends Component {
         <Calendar selectedDay={value}
                   min={min}
                   max={max}
+                  defaultMonth={defaultMonth}
                   onSelect={this.handleSelect.bind(this)}/>
       </div>
     </div>);


### PR DESCRIPTION
Pass `defaultMonth` from `DatePicker` to `Calendar`, and when there is no `defaultMonth` but `min` is set, use it as `defaultMonth`.

Thanks for your great work.
