### PR TITLE
kinda add clear value - fix not showing initial value - fixes #24

### DIFF
--- a/examples/src/components/App.js
+++ b/examples/src/components/App.js
@@ -14,7 +14,8 @@ const generateRandomMoment = () => {
 
 export default class App extends Component {
   state = {
-    value: moment()
+    value: moment(),
+    someValue: new moment()
   };
 
   render() {
@@ -45,6 +46,23 @@ export default class App extends Component {
               code={basicDatePickerCode}
             >
               <DatePicker />
+            </Example>
+          </div>
+          <div>
+            <Example
+              title="ورود تاریخ کنترل شده"
+              code={clearDatePickerCode}
+            >
+              <DatePicker
+                value={this.state.someValue}
+                x={true}
+                onChange={value => this.setState({ someValue: value })}
+              />
+              <div style={{ paddingTop: 15 }}>
+                <button onClick={() => this.setState({ someValue: null }) }>
+                  حذف مقدار
+                </button>
+              </div>
             </Example>
           </div>
           <div>
@@ -100,6 +118,21 @@ export default class App extends Component {
 
 const basicDatePickerCode = `render() {
   return <DatePicker />;
+}`;
+
+
+const clearDatePickerCode = `render() {
+  return (
+    <div>
+      <DatePicker
+        value={this.state.value}
+        onChange={value => this.setState({ value })}
+      />
+      <button onClick={() => this.setState({ value: null }) }>
+        حذف مقدار
+      </button>
+    </div>
+  );
 }`;
 
 const controlledDatePickerCode = `render() {

--- a/examples/src/components/App.js
+++ b/examples/src/components/App.js
@@ -55,7 +55,6 @@ export default class App extends Component {
             >
               <DatePicker
                 value={this.state.someValue}
-                x={true}
                 onChange={value => this.setState({ someValue: value })}
               />
               <div style={{ paddingTop: 15 }}>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-persian-datepicker",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Persian calendar and date picker components for React",
   "main": "lib/index.js",
   "scripts": {

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -54,7 +54,9 @@ export default class DatePicker extends Component {
       this.props.onChange(momentValue);
     }
 
-    const inputValue = momentValue.format(inputFormat);
+    let inputValue = "";
+    if (momentValue)
+      inputValue = momentValue.format(inputFormat);
     this.setState({ momentValue, inputValue });
   }
 
@@ -117,7 +119,13 @@ export default class DatePicker extends Component {
   }
 
   renderInput() {
-    const { isOpen, inputValue } = this.state;
+    let { isOpen, inputValue } = this.state;
+
+    if (this.props.value) {
+      let value = this.props.value;
+      let inputFormat = this.props.inputFormat;
+      inputValue = value.format(inputFormat);
+    }
 
     const className = classnames(this.props.className, {
       [outsideClickIgnoreClass]: isOpen


### PR DESCRIPTION
Clearly it's not a real fix for this problem. Just a hack to do it, It's on contributors to accept it as a fix.

The cleaner solution is to rewrite codes that setting `prop.value` to `state.value` (and something like this for `inputValue`) make clear difference between controlled and uncontrolled component usage (and also send a warning to developer if he changed component from controlled to uncontrolled or vice versa - like they did in [material-ui components](https://github.com/callemall/material-ui)) but since it's a major change it would be better to have milestone to do.

I should say thanks guys for bringing this component open source and I try to be available if any help needed.